### PR TITLE
Add Qt dependencies to the Linux docker build as a workaround

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -37,6 +37,9 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
+# library dependencies for qimage2ndarray
+yum install -y libXext libXrender libSM tk libX11-devel
+
 conda info
 
 


### PR DESCRIPTION
Uses the workaround proposed here ( https://github.com/conda-forge/docker-images/issues/1#issuecomment-197597726 ) to install the Qt dependencies in the Linux docker container. Eventually this will not be needed as they will be included in the new docker container. Until then, this is a required workaround. This will need to be re-added whenever the feedstock is re-rendered until such time when the docker container has them.