### PR TITLE
Bump to version 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Feedstock license: BSD 3-Clause
 
 Summary: Conversion between QImages and numpy.ndarrays.
 
+qimage2ndarray is a small python extension for quickly converting
+between ``QImages`` and ``numpy.ndarrays`` (in both directions).
 
 
 Installing qimage2ndarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,11 @@ about:
   license: BSD 3-Clause
   license_family: BSD
   summary: Conversion between QImages and numpy.ndarrays.
+  description: |
+    qimage2ndarray is a small python extension for quickly converting
+    between ``QImages`` and ``numpy.ndarrays`` (in both directions).
+  doc_url: http://hmeine.github.io/qimage2ndarray
+  dev_url: https://github.com/hmeine/qimage2ndarray
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "qimage2ndarray" %}
-{% set version = "1.5.1" %}
-{% set sha256 = "5aaf480715436c7820c1ce94c039a0874b7de435274f5b772bd33b1dba0e736f" %}
+{% set version = "1.6" %}
+{% set sha256 = "92c1f3accc26f5762066f924ebc4f09c4f76ff483f97ed9fdc80843bc644f7c9" %}
 
 package:
   name: {{ name }}
@@ -12,19 +12,17 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
     - python
     - setuptools
-    - sip
 
   run:
     - python
     - numpy
-    - sip
     - pyqt 4.11.*
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,7 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy
     - sip
-    - pyqt 4.11.*
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,11 @@ about:
   home: https://github.com/hmeine/qimage2ndarray
   license: BSD 3-Clause
   license_family: BSD
+  # Requested the license file be packaged upstream.
+  #
+  # https://github.com/hmeine/qimage2ndarray/pull/10
+  #
+  #license_file: LICENSE.txt
   summary: Conversion between QImages and numpy.ndarrays.
   description: |
     qimage2ndarray is a small python extension for quickly converting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version="1.5.1" %}
+{% set name = "qimage2ndarray" %}
+{% set version = "1.5.1" %}
 
 package:
-  name: qimage2ndarray
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: qimage2ndarray-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/q/qimage2ndarray/qimage2ndarray-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 5aaf480715436c7820c1ce94c039a0874b7de435274f5b772bd33b1dba0e736f
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: qimage2ndarray-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/source/q/qimage2ndarray/qimage2ndarray-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/q/qimage2ndarray/qimage2ndarray-{{ version }}.tar.gz
   md5: 73743819ccf6043f237c6b7f63732674
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ test:
 about:
   home: https://github.com/hmeine/qimage2ndarray
   license: BSD 3-Clause
+  license_family: BSD
   summary: Conversion between QImages and numpy.ndarrays.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: qimage2ndarray-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/q/qimage2ndarray/qimage2ndarray-{{ version }}.tar.gz
-  md5: 73743819ccf6043f237c6b7f63732674
+  sha256: 5aaf480715436c7820c1ce94c039a0874b7de435274f5b772bd33b1dba0e736f
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "qimage2ndarray" %}
 {% set version = "1.5.1" %}
+{% set sha256 = "5aaf480715436c7820c1ce94c039a0874b7de435274f5b772bd33b1dba0e736f" %}
 
 package:
   name: {{ name }}
@@ -8,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5aaf480715436c7820c1ce94c039a0874b7de435274f5b772bd33b1dba0e736f
+  sha256: {{ sha256 }}
 
 build:
   number: 1


### PR DESCRIPTION
There is a 1.6 release for `qimage2ndarray`. This switches the feedstock over to that version.
