### PR TITLE
Pin PyQt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,16 @@ install:
     - cmd: rmdir C:\cygwin /s /q
     - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add a hack to switch to `conda` version `4.1.12` before activating.
+    # This is required to handle a long path activation issue.
+    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
+
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 73743819ccf6043f237c6b7f63732674
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -19,13 +19,13 @@ requirements:
     - setuptools
     - numpy
     - sip
-    - pyqt
+    - pyqt 4.11.*
 
   run:
     - python
     - numpy
     - sip
-    - pyqt
+    - pyqt 4.11.*
 
 test:
   imports:


### PR DESCRIPTION
Closes https://github.com/conda-forge/qimage2ndarray-feedstock/pull/12
Closes https://github.com/conda-forge/qimage2ndarray-feedstock/pull/13

* Re-renders with `conda-smithy` version `1.3.3`. ( https://github.com/conda-forge/qimage2ndarray-feedstock/pull/13 )
* Also pins PyQt to version `4.11.*` to match the pinning wiki. ( https://github.com/conda-forge/qimage2ndarray-feedstock/pull/12 )