### PR TITLE
Unpin PyQt

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,9 @@ requirements:
 
 test:
   imports:
+    # Need to import Python-bindings first
+    # so that qimage2ndarray recognizes them.
+    - PyQt5
     - qimage2ndarray
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - numpy
-    - pyqt 4.11.*
+    - pyqt
 
 test:
   imports:


### PR DESCRIPTION
Replaces PR ( https://github.com/conda-forge/qimage2ndarray-feedstock/pull/19 ).

This can use PyQt 4 or PyQt 5. So unpin the PyQt version and rebuild.