### PR TITLE
Drop explicit PyQt requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -23,9 +23,11 @@ requirements:
   run:
     - python
     - numpy
-    - pyqt
 
 test:
+  requires:
+    - pyqt 5*
+
   imports:
     # Need to import Python-bindings first
     # so that qimage2ndarray recognizes them.


### PR DESCRIPTION
...since qimage2ndarray supports multiple Qt bindings.
See discussion in #4.